### PR TITLE
Fix recurring reminder local sync

### DIFF
--- a/icloudbridge/sources/reminders/eventkit.py
+++ b/icloudbridge/sources/reminders/eventkit.py
@@ -508,7 +508,7 @@ class RemindersAdapter:
                         EKRecurrenceDayOfWeek.dayOfWeek_(day) for day in rec_data.days_of_week
                     ]
 
-                rule = EKRecurrenceRule.alloc().initWithRecurrenceWithFrequency_interval_daysOfTheWeek_daysOfTheMonth_monthsOfTheYear_weeksOfTheYear_daysOfTheYear_setPositions_end_(
+                rule = EKRecurrenceRule.alloc().initRecurrenceWithFrequency_interval_daysOfTheWeek_daysOfTheMonth_monthsOfTheYear_weeksOfTheYear_daysOfTheYear_setPositions_end_(
                     frequency,
                     rec_data.interval,
                     days_of_week,


### PR DESCRIPTION
When syncing a reminder with a recurrence rule, the following error shows up:

```
Failed to create local reminder 'test recurrence': 'EKRecurrenceRule' object has no  reminders_sync.py:544 attribute 'initWithRecurrenceWithFrequency_interval_daysOfTheWeek_daysOfTheMonth_monthsOfTheYear_weeksOfTheYear_daysOfTheYear_setPositions_end_'      
```

This is because the recurrence rule was being initialized with a method that does not exist: `initWithRecurrenceWithFrequency_interval_daysOfTheWeek_daysOfTheMonth_monthsOfTheYear_weeksOfTheYear_daysOfTheYear_setPositions_end_`.

The correct method name is `initRecurrenceWithFrequency_interval_daysOfTheWeek_daysOfTheMonth_monthsOfTheYear_weeksOfTheYear_daysOfTheYear_setPositions_end_`